### PR TITLE
Remove expired elements from concurrency set

### DIFF
--- a/src/RedisRateLimiting/Concurrency/RedisConcurrencyRateLimiter.cs
+++ b/src/RedisRateLimiting/Concurrency/RedisConcurrencyRateLimiter.cs
@@ -16,7 +16,9 @@ namespace RedisRateLimiting
         private static readonly LuaScript _redisScript = LuaScript.Prepare(
           @"local limit = tonumber(@permit_limit)
             local timestamp = tonumber(@current_time)
+            local ttl = 60
 
+            redis.call(""zremrangebyscore"", @rate_limit_key, '-inf', timestamp - ttl)
             local count = redis.call(""zcard"", @rate_limit_key)
             local allowed = count < limit
 


### PR DESCRIPTION
Feedback from Reuben Bond:

> Your current concurrency limiter implementation appears to be not fault-tolerant: if a client crashes while holding onto a token then that token will never be returned. You could potentially DoS the system after a crash, since there will be no free permits.