### PR TITLE
provide Microsoft.AspNetCore.RateLimiting via FrameworkReference

### DIFF
--- a/src/RedisRateLimiting.AspNetCore/RedisRateLimiting.AspNetCore.csproj
+++ b/src/RedisRateLimiting.AspNetCore/RedisRateLimiting.AspNetCore.csproj
@@ -24,7 +24,7 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.RateLimiting" Version="7.0.0-rc.2.22476.2" />
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<ProjectReference Include="..\RedisRateLimiting\RedisRateLimiting.csproj" />


### PR DESCRIPTION
Microsoft.AspNetCore.RateLimiting was removed as a PackageReference and replaced by a FrameworkReference (Microsoft.AspNetCore.App) since it is now included in AspNetCore by default and the used nuget package (Microsoft.AspNetCore.RateLimiting) seems to be deprecated.