### PR TITLE
Fix: RedisTokenBucketRateLimiter does not refill and block randomly anymore

### DIFF
--- a/src/RedisRateLimiting/TokenBucket/RedisTokenBucketManager.cs
+++ b/src/RedisRateLimiting/TokenBucket/RedisTokenBucketManager.cs
@@ -11,37 +11,55 @@ namespace RedisRateLimiting.Concurrency
         private readonly RedisKey RateLimitKey;
         private readonly RedisKey RateLimitTimestampKey;
 
-        private static readonly LuaScript _redisScript = LuaScript.Prepare(
-          @"local rate = tonumber(@tokens_per_period)
+        private static readonly LuaScript _redisScript = LuaScript.Prepare(@"
+            -- Prepare the input and force the correct data types.
             local limit = tonumber(@token_limit)
-            local requested = tonumber(@permit_count)
-            local now = tonumber(@current_time)
+            local rate = tonumber(@tokens_per_period)
             local period = tonumber(@replenish_period)
+            local requested = tonumber(@permit_count)
 
-            local current_tokens = tonumber(redis.call(""get"", @rate_limit_key))
-            if current_tokens == nil then
-              current_tokens = limit
-            end
+            -- Even though it is the default since Redis 5, we explicitly enable command replication.
+            -- This ensures that non-deterministic commands like 'TIME' are replicated by effect.
+            redis.replicate_commands()
 
-            local last_refreshed = tonumber(redis.call(""get"", @timestamp_key))
-            if last_refreshed == nil then
-              last_refreshed = 0
-            end
+            -- Retrieve the current time as unix timestamp with millisecond accuracy.
+            local time = redis.call('TIME')
+            local now = math.floor((time[1] * 1000) + (time[2] / 1000))
 
-            local delta_ts = math.max(0, now - last_refreshed)
-            local segments = math.floor(delta_ts / period)
-            current_tokens = math.min(limit, current_tokens + (segments * rate))
+            -- Load the current state from Redis. We use MGET to save a round-trip.
+            local state = redis.call('MGET', @rate_limit_key, @timestamp_key)
+            local current_tokens = tonumber(state[1]) or limit
+            local last_refreshed = tonumber(state[2]) or 0
 
+            -- Calculate the time and replenishment periods elapsed since the last call.
+            local time_since_last_refreshed = math.max(0, now - last_refreshed)
+            local periods_since_last_refreshed = math.floor(time_since_last_refreshed / period)
+
+            -- Now we have all the info we need to calculate the current tokens based on the elapsed time.
+            current_tokens = math.min(limit, current_tokens + (periods_since_last_refreshed * rate))
+
+            -- If the bucket contains enough tokens for the current request, we remove the tokens.
             local allowed = current_tokens >= requested
             if allowed then
                current_tokens = current_tokens - requested
             end
 
-            local fill_time = limit / rate
-            local ttl = math.floor(fill_time * 2)
+            -- In order to remove rate limit keys automatically from the database, we calculate a TTL
+            -- based on the worst-case scenario for the bucket to fill up again.
+            local periods_until_full = limit / rate
+            local ttl = math.ceil(periods_until_full * period)
 
-            redis.call(""setex"", @rate_limit_key, ttl, current_tokens)
-            redis.call(""setex"", @timestamp_key, ttl, now)
+            -- We only store the new state in the database if the request was granted.
+            -- This avoids rounding issues and edge cases which can occur if many requests are rate limited.
+            if allowed then
+                local time_of_last_replenishment = now
+                if last_refreshed > 0 then
+                    time_of_last_replenishment = last_refreshed + (periods_since_last_refreshed * period)
+                end
+
+                redis.call('SET', @rate_limit_key, current_tokens, 'EX', ttl)
+                redis.call('SET', @timestamp_key, time_of_last_replenishment, 'EX', ttl)
+            end
 
             return { allowed, current_tokens }");
 
@@ -67,13 +85,12 @@ namespace RedisRateLimiting.Concurrency
                 _redisScript,
                 new
                 {
-                    rate_limit_key = RateLimitKey,
-                    timestamp_key = RateLimitTimestampKey,
-                    current_time = nowUnixTimeSeconds,
-                    tokens_per_period = _options.TokensPerPeriod,
-                    token_limit = _options.TokenLimit,
-                    replenish_period = _options.ReplenishmentPeriod.TotalSeconds,
-                    permit_count = 1D,
+                    rate_limit_key = (RedisKey)RateLimitKey,
+                    timestamp_key = (RedisKey)RateLimitTimestampKey,
+                    tokens_per_period = (RedisValue)_options.TokensPerPeriod,
+                    token_limit = (RedisValue)_options.TokenLimit,
+                    replenish_period = (RedisValue)_options.ReplenishmentPeriod.TotalMilliseconds,
+                    permit_count = (RedisValue)1D,
                 });
 
             var result = new RedisTokenBucketResponse();
@@ -89,22 +106,18 @@ namespace RedisRateLimiting.Concurrency
 
         internal RedisTokenBucketResponse TryAcquireLease()
         {
-            var now = DateTimeOffset.UtcNow;
-            var nowUnixTimeSeconds = now.ToUnixTimeSeconds();
-
             var database = _connectionMultiplexer.GetDatabase();
 
             var response = (RedisValue[]?)database.ScriptEvaluate(
                 _redisScript,
                 new
                 {
-                    rate_limit_key = RateLimitKey,
-                    timestamp_key = RateLimitTimestampKey,
-                    current_time = nowUnixTimeSeconds,
-                    tokens_per_period = _options.TokensPerPeriod,
-                    token_limit = _options.TokenLimit,
-                    replenish_period = _options.ReplenishmentPeriod.TotalSeconds,
-                    permit_count = 1D,
+                    rate_limit_key = (RedisKey)RateLimitKey,
+                    timestamp_key = (RedisKey)RateLimitTimestampKey,
+                    tokens_per_period = (RedisValue)_options.TokensPerPeriod,
+                    token_limit = (RedisValue)_options.TokenLimit,
+                    replenish_period = (RedisValue)_options.ReplenishmentPeriod.TotalMilliseconds,
+                    permit_count = (RedisValue)1D,
                 });
 
             var result = new RedisTokenBucketResponse();

--- a/src/RedisRateLimiting/TokenBucket/RedisTokenBucketManager.cs
+++ b/src/RedisRateLimiting/TokenBucket/RedisTokenBucketManager.cs
@@ -59,8 +59,8 @@ namespace RedisRateLimiting.Concurrency
             -- We only store the new state in the database if the request was granted.
             -- This avoids rounding issues and edge cases which can occur if many requests are rate limited.
             if allowed then
-                redis.call('SET', @rate_limit_key, current_tokens, 'EX', ttl)
-                redis.call('SET', @timestamp_key, time_of_last_replenishment, 'EX', ttl)
+                redis.call('SET', @rate_limit_key, current_tokens, 'PX', ttl)
+                redis.call('SET', @timestamp_key, time_of_last_replenishment, 'PX', ttl)
             end
 
             -- Before we return, we can now also calculate when the client may retry again if they are rate limited.

--- a/src/RedisRateLimiting/TokenBucket/RedisTokenBucketManager.cs
+++ b/src/RedisRateLimiting/TokenBucket/RedisTokenBucketManager.cs
@@ -53,7 +53,8 @@ namespace RedisRateLimiting.Concurrency
 
             -- In order to remove rate limit keys automatically from the database, we calculate a TTL
             -- based on the worst-case scenario for the bucket to fill up again.
-            local periods_until_full = limit / rate
+            -- The worst case is when the bucket is empty and the last replenisment adds less tokens than available.
+            local periods_until_full = math.ceil(limit / rate)
             local ttl = math.ceil(periods_until_full * period)
 
             -- We only store the new state in the database if the request was granted.

--- a/src/RedisRateLimiting/TokenBucket/RedisTokenBucketRateLimiter.cs
+++ b/src/RedisRateLimiting/TokenBucket/RedisTokenBucketRateLimiter.cs
@@ -79,6 +79,7 @@ namespace RedisRateLimiting
 
             leaseContext.Allowed = response.Allowed;
             leaseContext.Count = response.Count;
+            leaseContext.RetryAfter = response.RetryAfter;
 
             if (leaseContext.Allowed)
             {
@@ -99,6 +100,7 @@ namespace RedisRateLimiting
 
             leaseContext.Allowed = response.Allowed;
             leaseContext.Count = response.Count;
+            leaseContext.RetryAfter = response.RetryAfter;
 
             if (leaseContext.Allowed)
             {
@@ -113,6 +115,8 @@ namespace RedisRateLimiting
             public long Count { get; set; }
 
             public long Limit { get; set; }
+
+            public int RetryAfter { get; set; }
 
             public bool Allowed { get; set; }
         }
@@ -144,6 +148,12 @@ namespace RedisRateLimiting
                 if (metadataName == RateLimitMetadataName.Remaining.Name && _context is not null)
                 {
                     metadata = _context.Count;
+                    return true;
+                }
+
+                if (metadataName == RateLimitMetadataName.RetryAfter.Name && _context is not null)
+                {
+                    metadata = _context.RetryAfter;
                     return true;
                 }
 


### PR DESCRIPTION
Fixes #46 

This PR reworks the Lua script used by the `RedisTokenBucketManager` in a few ways. The primary goal is to fix the issues mentioned in #46. Summary of the changes:
- The current time `now` is generated by Redis now, which is safe due to the use of `redis.replicate_commands()`. By letting Redis take the time itself, all requests are clocked by the same system, guaranteeing best accuracy.
- All timestamps are in milliseconds now, which is more accurate and allows working with sub-second `TimeSpan`s.
- `redis.call('GET', ...)` calls have been replaced with `redis.call('MGET', ...)` to safe a round-trip to the database.
- Some variables were renamed in order to give them a clearer name.
- The new `current_tokens` together with the timestamp are only persisted, if the request is allowed.
- The TTL for the persisted data is now calculated from the `periods_until_full` multiplied by the `period` (duration). This fixes the first issue described in #46.
- The persisted timestamp is not `now` anymore but the `time_of_last_replenishment`. This fixes the second issue described in #46.

Besides the changes to the Lua script, the PR also includes the following other changes:
- The parameters passed to Redis in `IRedisDatabase.ScriptEvaluate()` are now explicitly flagged as `(RedisKey)` or `(RedisValue)` respectively. This ensures that the parameters are mapped to the `KEYS[]` and `ARGS[]` arrays correctly, which is important for correct script execution (especially in clusters).
- The Lua script does now calculate `retry_after` (in milliseconds), which is `0` if the request was `allowed` or the milliseconds until the next token is generated if `not allowed`. This value is returned by the rate limiter in rounded up seconds.