### PR TITLE
Fix sub-second precision window usage

### DIFF
--- a/src/RedisRateLimiting/SlidingWindow/RedisSlidingWindowManager.cs
+++ b/src/RedisRateLimiting/SlidingWindow/RedisSlidingWindowManager.cs
@@ -28,7 +28,8 @@ namespace RedisRateLimiting.Concurrency
                 redis.call(""zadd"", @rate_limit_key, timestamp, @unique_id)
             end
 
-            redis.call(""expireat"", @rate_limit_key, timestamp + window + 1)
+            local expireAtMilliseconds = math.floor((timestamp + window) * 1000 + 1);
+            redis.call(""pexpireat"", @rate_limit_key, expireAtMilliseconds)
 
             if allowed
             then
@@ -60,7 +61,7 @@ namespace RedisRateLimiting.Concurrency
         internal async Task<RedisSlidingWindowResponse> TryAcquireLeaseAsync(string requestId)
         {
             var now = DateTimeOffset.UtcNow;
-            var nowUnixTimeSeconds = now.ToUnixTimeSeconds();
+            double nowUnixTimeSeconds = now.ToUnixTimeMilliseconds() / 1000.0;
 
             var database = _connectionMultiplexer.GetDatabase();
 
@@ -90,7 +91,7 @@ namespace RedisRateLimiting.Concurrency
         internal RedisSlidingWindowResponse TryAcquireLease(string requestId)
         {
             var now = DateTimeOffset.UtcNow;
-            var nowUnixTimeSeconds = now.ToUnixTimeSeconds();
+            double nowUnixTimeSeconds = now.ToUnixTimeMilliseconds() / 1000.0;
 
             var database = _connectionMultiplexer.GetDatabase();
 

--- a/test/RedisRateLimiting.Tests/UnitTests/SlidingWindowUnitTests.cs
+++ b/test/RedisRateLimiting.Tests/UnitTests/SlidingWindowUnitTests.cs
@@ -106,5 +106,32 @@ namespace RedisRateLimiting.Tests.UnitTests
             stats = limiter.GetStatistics()!;
             Assert.Equal(0, stats.CurrentAvailablePermits);
         }
+
+        [Fact]
+        public async Task CanAcquireAsyncResourceWithSmallWindow()
+        {
+            using var limiter = new RedisSlidingWindowRateLimiter<string>(
+                string.Empty,
+                new RedisSlidingWindowRateLimiterOptions
+                {
+                    PermitLimit = 1,
+                    Window = TimeSpan.FromMilliseconds(100),
+                    ConnectionMultiplexerFactory = Fixture.ConnectionMultiplexerFactory,
+                });
+
+            using var lease = await limiter.AcquireAsync();
+            Assert.True(lease.IsAcquired);
+
+            using var lease2 = await limiter.AcquireAsync();
+            Assert.False(lease2.IsAcquired);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+            using var lease3 = await limiter.AcquireAsync();
+            Assert.True(lease3.IsAcquired);
+
+            using var lease4 = await limiter.AcquireAsync();
+            Assert.False(lease4.IsAcquired);
+        }
     }
 }


### PR DESCRIPTION
Fixes #62 . Previously specifying a sub-second precision window for the sliding window rate limiter caused an error at runtime as the value was passed to redis as a double while EXPIREAT expects an integer. This patch fixes this problem and increases the precision of the window to milliseconds as requested in the issue discussion.