### PR TITLE
Added .NET Standard 2.0 support to library

### DIFF
--- a/src/RedisRateLimiting/RedisRateLimiting.csproj
+++ b/src/RedisRateLimiting/RedisRateLimiting.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<RootNamespace>RedisRateLimiting</RootNamespace>
 		<Description>Redis extensions for .NET 7.0 rate limiting</Description>


### PR DESCRIPTION
We needed .NET Standard 2.0 support in our use case. This PR contains changes related to spot which is not compatible with it. I know that using `System.Timers.Timer` is a step back compared to `PeriodicTimer` but changing target framework makes this library much more flexible.