### PR TITLE
Implement IdleDuration for RedisTokenBucketRateLimiter

### DIFF
--- a/src/RedisRateLimiting/TokenBucket/RedisTokenBucketRateLimiter.cs
+++ b/src/RedisRateLimiting/TokenBucket/RedisTokenBucketRateLimiter.cs
@@ -1,6 +1,7 @@
 ﻿using RedisRateLimiting.Concurrency;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.RateLimiting;
 using System.Threading.Tasks;
@@ -14,7 +15,12 @@ namespace RedisRateLimiting
 
         private readonly TokenBucketLease FailedLease = new(isAcquired: false, null);
 
-        public override TimeSpan? IdleDuration => TimeSpan.Zero;
+        private int _activeRequestsCount;
+        private long _lastActiveTimestamp = Stopwatch.GetTimestamp();
+
+        public override TimeSpan? IdleDuration => Interlocked.CompareExchange(ref _activeRequestsCount, 0, 0) > 0
+            ? TimeSpan.Zero
+            : TimeSpan.FromTicks(Stopwatch.GetTimestamp() - _lastActiveTimestamp);
 
         public RedisTokenBucketRateLimiter(TKey partitionKey, RedisTokenBucketRateLimiterOptions options)
         {
@@ -55,14 +61,24 @@ namespace RedisRateLimiting
             throw new NotImplementedException();
         }
 
-        protected override ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
+        protected override async ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
         {
+            _lastActiveTimestamp = Stopwatch.GetTimestamp();
             if (permitCount > _options.TokenLimit)
             {
                 throw new ArgumentOutOfRangeException(nameof(permitCount), permitCount, string.Format("{0} permit(s) exceeds the permit limit of {1}.", permitCount, _options.TokenLimit));
             }
 
-            return AcquireAsyncCoreInternal(permitCount);
+            Interlocked.Increment(ref _activeRequestsCount);
+            try
+            {
+                return await AcquireAsyncCoreInternal(permitCount);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _activeRequestsCount);
+                _lastActiveTimestamp = Stopwatch.GetTimestamp();
+            }
         }
 
         protected override RateLimitLease AttemptAcquireCore(int permitCount)


### PR DESCRIPTION
Fix issue in RedisTokenBucketRateLimiter similar to https://github.com/cristipufu/aspnetcore-redis-rate-limiting/issues/61
The current implementation always returns TimeSpan.Zero for [RateLimiter.IdleDuration](https://learn.microsoft.com/en-us/dotnet/api/system.threading.ratelimiting.ratelimiter.idleduration?view=aspnetcore-7.0#system-threading-ratelimiting-ratelimiter-idleduration). When using a partitioned rate limiter this means the rate limiters created for the partitions [never get cleaned up](https://github.com/dotnet/runtime/blob/c3859ad70b3d5d02b252d07c904160eada32d653/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs#LL229C17-L229C17) and will accumulate.

Behavior before fix: growing memory up until pod limit, causing pod restarts. 100k unique IP/day, causing 100k+ rate limiters in memory. Growing CPU utilization which is caused by .Net trying to find rate limiters to cleanup.
![image](https://github.com/cristipufu/aspnetcore-redis-rate-limiting/assets/14337206/8654e2c5-31f9-42a1-831f-21ca5b9b1533)

Implementation notes:
- Interlocked operations are required to avoid using lock (...) and protect from imprecise IdleDuration responses in situation when same rate limiter is used to handle multiple simultaneous requests
- Unit tests do not cover case when IdleDuration is returned as TimeSpan.Zero. To cover that we need to introduce some mocks library.
