### PR TITLE
Feature/support more async operations and fix disposal bug

### DIFF
--- a/src/RedisRateLimiting/Concurrency/RedisConcurrencyManager.cs
+++ b/src/RedisRateLimiting/Concurrency/RedisConcurrencyManager.cs
@@ -1,4 +1,5 @@
 ﻿using StackExchange.Redis;
+
 using System;
 using System.Threading.RateLimiting;
 using System.Threading.Tasks;
@@ -204,6 +205,33 @@ internal class RedisConcurrencyManager
         var database = _connectionMultiplexer.GetDatabase();
 
         var response = (RedisValue[]?)database.ScriptEvaluate(
+            StatisticsScript,
+            new
+            {
+                rate_limit_key = RateLimitKey,
+                queue_key = QueueRateLimitKey,
+                stats_key = StatsRateLimitKey,
+            });
+
+        if (response == null)
+        {
+            return null;
+        }
+
+        return new RateLimiterStatistics
+        {
+            CurrentAvailablePermits = _options.PermitLimit + _options.QueueLimit - (long)response[0] - (long)response[1],
+            CurrentQueuedCount = (long)response[1],
+            TotalSuccessfulLeases = (long)response[2],
+            TotalFailedLeases = (long)response[3],
+        };
+    }
+
+    internal async Task<RateLimiterStatistics?> GetStatisticsAsync()
+    {
+        var database = _connectionMultiplexer.GetDatabase();
+
+        var response = (RedisValue[]?)await database.ScriptEvaluateAsync(
             StatisticsScript,
             new
             {

--- a/src/RedisRateLimiting/Concurrency/RedisConcurrencyManager.cs
+++ b/src/RedisRateLimiting/Concurrency/RedisConcurrencyManager.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace RedisRateLimiting.Concurrency;
 
-internal class RedisConcurrencyManager
+internal class RedisConcurrencyManager : IDisposable
 {
     private readonly IConnectionMultiplexer _connectionMultiplexer;
     private readonly RedisConcurrencyRateLimiterOptions _options;
@@ -101,6 +101,7 @@ internal class RedisConcurrencyManager
             local total_failed_count = redis.call(""hget"", @stats_key, 'total_failed')
 
             return { count, queue_count, total_successful_count, total_failed_count }");
+    private bool disposedValue;
 
     public RedisConcurrencyManager(
         string partitionKey,
@@ -252,6 +253,26 @@ internal class RedisConcurrencyManager
             TotalSuccessfulLeases = (long)response[2],
             TotalFailedLeases = (long)response[3],
         };
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposedValue)
+        {
+            if (disposing)
+            {
+                _connectionMultiplexer?.Dispose();
+            }
+
+            disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }
 

--- a/src/RedisRateLimiting/Concurrency/RedisConcurrencyRateLimiter.cs
+++ b/src/RedisRateLimiting/Concurrency/RedisConcurrencyRateLimiter.cs
@@ -158,6 +158,14 @@ public class RedisConcurrencyRateLimiter<TKey> : RateLimiter
         _ = _redisManager.ReleaseLeaseAsync(leaseContext.RequestId);
     }
 
+    private async Task ReleaseAsync(ConcurencyLeaseContext leaseContext)
+    {
+        if (leaseContext.RequestId is null)
+            return;
+
+        await _redisManager.ReleaseLeaseAsync(leaseContext.RequestId);
+    }
+
     private async Task StartDequeueTimerAsync(PeriodicTimer periodicTimer)
     {
         while (await periodicTimer.WaitForNextTickAsync())
@@ -266,7 +274,7 @@ public class RedisConcurrencyRateLimiter<TKey> : RateLimiter
         public long Limit { get; set; }
     }
 
-    private sealed class ConcurrencyLease : RateLimitLease
+    private sealed class ConcurrencyLease : RateLimitLease, IAsyncDisposable
     {
         private static readonly string[] s_allMetadataNames = { RateLimitMetadataName.Limit.Name, RateLimitMetadataName.Remaining.Name };
 
@@ -315,6 +323,30 @@ public class RedisConcurrencyRateLimiter<TKey> : RateLimiter
             if (_context != null)
             {
                 _limiter?.Release(_context);
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore();
+
+            GC.SuppressFinalize(this);
+        }
+
+        // Not stricktly required in a sealed class, we could just implement DisposeAsync directly, but this
+        // pattern allows for the class to be unsealed in the future without breaking the async disposal pattern.
+        private async ValueTask DisposeAsyncCore()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            if (_context != null && _limiter != null)
+            {
+                await _limiter.ReleaseAsync(_context);
             }
         }
     }

--- a/src/RedisRateLimiting/Concurrency/RedisConcurrencyRateLimiter.cs
+++ b/src/RedisRateLimiting/Concurrency/RedisConcurrencyRateLimiter.cs
@@ -255,6 +255,8 @@ public class RedisConcurrencyRateLimiter<TKey> : RateLimiter
             request?.TaskCompletionSource?.TrySetResult(FailedLease);
         }
 
+        _redisManager?.Dispose();
+
         base.Dispose(disposing);
     }
 

--- a/src/RedisRateLimiting/Concurrency/RedisConcurrencyRateLimiter.cs
+++ b/src/RedisRateLimiting/Concurrency/RedisConcurrencyRateLimiter.cs
@@ -1,4 +1,5 @@
 ﻿using RedisRateLimiting.Concurrency;
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -71,6 +72,11 @@ public class RedisConcurrencyRateLimiter<TKey> : RateLimiter
     public override RateLimiterStatistics? GetStatistics()
     {
         return _redisManager.GetStatistics();
+    }
+
+    public async Task<RateLimiterStatistics?> GetStatisticsAsync()
+    {
+        return await _redisManager.GetStatisticsAsync();
     }
 
     protected override async ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
@@ -146,7 +152,8 @@ public class RedisConcurrencyRateLimiter<TKey> : RateLimiter
 
     private void Release(ConcurencyLeaseContext leaseContext)
     {
-        if (leaseContext.RequestId is null) return;
+        if (leaseContext.RequestId is null)
+            return;
 
         _ = _redisManager.ReleaseLeaseAsync(leaseContext.RequestId);
     }

--- a/src/RedisRateLimiting/FixedWindow/RedisFixedWindowManager.cs
+++ b/src/RedisRateLimiting/FixedWindow/RedisFixedWindowManager.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace RedisRateLimiting.Concurrency;
 
-internal class RedisFixedWindowManager
+internal class RedisFixedWindowManager : IDisposable
 {
     private readonly IConnectionMultiplexer _connectionMultiplexer;
     private readonly RedisFixedWindowRateLimiterOptions _options;
@@ -50,6 +50,7 @@ internal class RedisFixedWindowManager
 
             return { current, expires_at, allowed } 
         ");
+    private bool disposedValue;
 
     public RedisFixedWindowManager(
         string partitionKey,
@@ -122,6 +123,26 @@ internal class RedisFixedWindowManager
         }
 
         return result;
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposedValue)
+        {
+            if (disposing)
+            {
+                _connectionMultiplexer?.Dispose();
+            }
+
+            disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }
 

--- a/src/RedisRateLimiting/FixedWindow/RedisFixedWindowRateLimiter.cs
+++ b/src/RedisRateLimiting/FixedWindow/RedisFixedWindowRateLimiter.cs
@@ -13,6 +13,8 @@ public class RedisFixedWindowRateLimiter<TKey> : RateLimiter
     private readonly RedisFixedWindowManager _redisManager;
     private readonly RedisFixedWindowRateLimiterOptions _options;
 
+    private bool _disposed;
+
     private readonly FixedWindowLease FailedLease = new(isAcquired: false, null);
 
     private int _activeRequestsCount;
@@ -95,6 +97,25 @@ public class RedisFixedWindowRateLimiter<TKey> : RateLimiter
         leaseContext.ExpiresAt = response.ExpiresAt;
 
         return new FixedWindowLease(isAcquired: response.Allowed, leaseContext);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            return;
+        }
+
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        _redisManager?.Dispose();
+
+        base.Dispose(disposing);
     }
 
     private sealed class FixedWindowLeaseContext

--- a/src/RedisRateLimiting/SlidingWindow/RedisSlidingWindowManager.cs
+++ b/src/RedisRateLimiting/SlidingWindow/RedisSlidingWindowManager.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace RedisRateLimiting.Concurrency;
 
-internal class RedisSlidingWindowManager
+internal class RedisSlidingWindowManager : IDisposable
 {
     private readonly IConnectionMultiplexer _connectionMultiplexer;
     private readonly RedisSlidingWindowRateLimiterOptions _options;
@@ -49,6 +49,7 @@ internal class RedisSlidingWindowManager
             local total_failed_count = redis.call(""hget"", @stats_key, 'total_failed')
 
             return { count, total_successful_count, total_failed_count }");
+    private bool disposedValue;
 
     public RedisSlidingWindowManager(
         string partitionKey,
@@ -169,6 +170,26 @@ internal class RedisSlidingWindowManager
             TotalSuccessfulLeases = (long)response[1],
             TotalFailedLeases = (long)response[2],
         };
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposedValue)
+        {
+            if (disposing)
+            {
+                _connectionMultiplexer?.Dispose();
+            }
+
+            disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }
 

--- a/src/RedisRateLimiting/SlidingWindow/RedisSlidingWindowManager.cs
+++ b/src/RedisRateLimiting/SlidingWindow/RedisSlidingWindowManager.cs
@@ -1,4 +1,5 @@
 ﻿using StackExchange.Redis;
+
 using System;
 using System.Threading.RateLimiting;
 using System.Threading.Tasks;
@@ -125,6 +126,31 @@ internal class RedisSlidingWindowManager
         var database = _connectionMultiplexer.GetDatabase();
 
         var response = (RedisValue[]?)database.ScriptEvaluate(
+            StatisticsScript,
+            new
+            {
+                rate_limit_key = RateLimitKey,
+                stats_key = StatsRateLimitKey,
+            });
+
+        if (response == null)
+        {
+            return null;
+        }
+
+        return new RateLimiterStatistics
+        {
+            CurrentAvailablePermits = _options.PermitLimit - (long)response[0],
+            TotalSuccessfulLeases = (long)response[1],
+            TotalFailedLeases = (long)response[2],
+        };
+    }
+
+    internal async Task<RateLimiterStatistics?> GetStatisticsAsync()
+    {
+        var database = _connectionMultiplexer.GetDatabase();
+
+        var response = (RedisValue[]?)await database.ScriptEvaluateAsync(
             StatisticsScript,
             new
             {

--- a/src/RedisRateLimiting/SlidingWindow/RedisSlidingWindowRateLimiter.cs
+++ b/src/RedisRateLimiting/SlidingWindow/RedisSlidingWindowRateLimiter.cs
@@ -14,6 +14,8 @@ public class RedisSlidingWindowRateLimiter<TKey> : RateLimiter
     private readonly RedisSlidingWindowManager _redisManager;
     private readonly RedisSlidingWindowRateLimiterOptions _options;
 
+    private bool _disposed;
+
     private readonly SlidingWindowLease FailedLease = new(isAcquired: false, null);
 
     private int _activeRequestsCount;
@@ -106,6 +108,25 @@ public class RedisSlidingWindowRateLimiter<TKey> : RateLimiter
         }
 
         return new SlidingWindowLease(isAcquired: false, leaseContext);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            return;
+        }
+
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        _redisManager?.Dispose();
+
+        base.Dispose(disposing);
     }
 
     private sealed class SlidingWindowLeaseContext

--- a/src/RedisRateLimiting/SlidingWindow/RedisSlidingWindowRateLimiter.cs
+++ b/src/RedisRateLimiting/SlidingWindow/RedisSlidingWindowRateLimiter.cs
@@ -1,4 +1,5 @@
 ﻿using RedisRateLimiting.Concurrency;
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -52,6 +53,11 @@ public class RedisSlidingWindowRateLimiter<TKey> : RateLimiter
     public override RateLimiterStatistics? GetStatistics()
     {
         return _redisManager.GetStatistics();
+    }
+
+    public async Task<RateLimiterStatistics?> GetStatisticsAsync()
+    {
+        return await _redisManager.GetStatisticsAsync();
     }
 
     protected override async ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)

--- a/src/RedisRateLimiting/TokenBucket/RedisTokenBucketManager.cs
+++ b/src/RedisRateLimiting/TokenBucket/RedisTokenBucketManager.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace RedisRateLimiting.Concurrency;
 
-internal class RedisTokenBucketManager
+internal class RedisTokenBucketManager : IDisposable
 {
     private readonly IConnectionMultiplexer _connectionMultiplexer;
     private readonly RedisTokenBucketRateLimiterOptions _options;
@@ -64,6 +64,7 @@ internal class RedisTokenBucketManager
             end
 
             return { allowed, current_tokens, retry_after }");
+    private bool disposedValue;
 
     public RedisTokenBucketManager(
         string partitionKey,
@@ -132,6 +133,26 @@ internal class RedisTokenBucketManager
         }
 
         return result;
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposedValue)
+        {
+            if (disposing)
+            {
+                _connectionMultiplexer?.Dispose();
+            }
+
+            disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }
 

--- a/src/RedisRateLimiting/TokenBucket/RedisTokenBucketRateLimiter.cs
+++ b/src/RedisRateLimiting/TokenBucket/RedisTokenBucketRateLimiter.cs
@@ -13,6 +13,8 @@ public class RedisTokenBucketRateLimiter<TKey> : RateLimiter
     private readonly RedisTokenBucketManager _redisManager;
     private readonly RedisTokenBucketRateLimiterOptions _options;
 
+    private bool _disposed;
+
     private readonly TokenBucketLease FailedLease = new(isAcquired: false, null);
 
     private int _activeRequestsCount;
@@ -104,6 +106,25 @@ public class RedisTokenBucketRateLimiter<TKey> : RateLimiter
         }
 
         return new TokenBucketLease(isAcquired: false, leaseContext);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            return;
+        }
+
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        _redisManager?.Dispose();
+
+        base.Dispose(disposing);
     }
 
     private sealed class TokenBucketLeaseContext

--- a/test/RedisRateLimiting.Tests/UnitTests/ConcurrencyUnitTests.cs
+++ b/test/RedisRateLimiting.Tests/UnitTests/ConcurrencyUnitTests.cs
@@ -435,6 +435,53 @@ public class ConcurrencyUnitTests(TestFixture fixture) : IClassFixture<TestFixtu
         Assert.Equal(stats.CurrentAvailablePermits, asyncStats.CurrentAvailablePermits);
     }
 
+    [Fact]
+    public async Task CanAcquireAsyncResourceAfterAsyncDispose()
+    {
+        using var limiter = new RedisConcurrencyRateLimiter<string>(
+            partitionKey: Guid.NewGuid().ToString(),
+            new RedisConcurrencyRateLimiterOptions
+            {
+                PermitLimit = 1,
+                ConnectionMultiplexerFactory = Fixture.ConnectionMultiplexerFactory,
+            });
+
+        var lease = await limiter.AcquireAsync();
+        Assert.True(lease.IsAcquired);
+
+        var lease2 = await limiter.AcquireAsync();
+        Assert.False(lease2.IsAcquired);
+
+        if (lease is IAsyncDisposable asyncDisposableLease)
+        {
+            await asyncDisposableLease.DisposeAsync();
+        }
+        else
+        {
+            lease.Dispose();
+        }
+
+        lease = await limiter.AcquireAsync();
+        Assert.True(lease.IsAcquired);
+
+        var stats = limiter.GetStatistics();
+        Assert.Equal(2, stats.TotalSuccessfulLeases);
+        Assert.Equal(1, stats.TotalFailedLeases);
+        Assert.Equal(0, stats.CurrentAvailablePermits);
+
+        if (lease is IAsyncDisposable asyncDisposableLease3)
+        {
+            await asyncDisposableLease3.DisposeAsync();
+        }
+        else
+        {
+            lease.Dispose();
+        }
+
+        stats = limiter.GetStatistics();
+        Assert.Equal(1, stats.CurrentAvailablePermits);
+    }
+
     static internal void ForceDequeue(RedisConcurrencyRateLimiter<string> limiter)
     {
         var dequeueRequestsMethod = typeof(RedisConcurrencyRateLimiter<string>)

--- a/test/RedisRateLimiting.Tests/UnitTests/ConcurrencyUnitTests.cs
+++ b/test/RedisRateLimiting.Tests/UnitTests/ConcurrencyUnitTests.cs
@@ -402,6 +402,39 @@ public class ConcurrencyUnitTests(TestFixture fixture) : IClassFixture<TestFixtu
         Assert.True(limiter.IdleDuration < previousIdleDuration);
     }
 
+    [Fact]
+    public async Task GetStatisticsAndGetStatisticsAsyncReturnIdenticalResult()
+    {
+        using var limiter = new RedisConcurrencyRateLimiter<string>(
+                    partitionKey: Guid.NewGuid().ToString(),
+                    new RedisConcurrencyRateLimiterOptions
+                    {
+                        PermitLimit = 1,
+                        ConnectionMultiplexerFactory = Fixture.ConnectionMultiplexerFactory,
+                    });
+
+        var lease = await limiter.AcquireAsync();
+        var lease2 = await limiter.AcquireAsync();
+
+        lease.Dispose();
+        lease = await limiter.AcquireAsync();
+
+        var stats = limiter.GetStatistics();
+        var asyncStats = await limiter.GetStatisticsAsync();
+
+        // The earlier CanAcquireAsyncResource() test validates that the stats are correct,
+        // so here we just want to validate that both methods return the same result.
+        Assert.Equal(stats.TotalSuccessfulLeases, asyncStats.TotalSuccessfulLeases);
+        Assert.Equal(stats.TotalFailedLeases, asyncStats.TotalFailedLeases);
+        Assert.Equal(stats.CurrentAvailablePermits, asyncStats.CurrentAvailablePermits);
+
+        lease.Dispose();
+
+        stats = limiter.GetStatistics();
+        asyncStats = await limiter.GetStatisticsAsync();
+        Assert.Equal(stats.CurrentAvailablePermits, asyncStats.CurrentAvailablePermits);
+    }
+
     static internal void ForceDequeue(RedisConcurrencyRateLimiter<string> limiter)
     {
         var dequeueRequestsMethod = typeof(RedisConcurrencyRateLimiter<string>)

--- a/test/RedisRateLimiting.Tests/UnitTests/SlidingWindowUnitTests.cs
+++ b/test/RedisRateLimiting.Tests/UnitTests/SlidingWindowUnitTests.cs
@@ -124,7 +124,7 @@ public class SlidingWindowUnitTests(TestFixture fixture) : IClassFixture<TestFix
         using var lease4 = await limiter.AcquireAsync();
         Assert.False(lease4.IsAcquired);
     }
-    
+
     [Fact]
     public async Task IdleDurationIsUpdated()
     {
@@ -142,5 +142,40 @@ public class SlidingWindowUnitTests(TestFixture fixture) : IClassFixture<TestFix
         var previousIdleDuration = limiter.IdleDuration;
         using var lease = await limiter.AcquireAsync();
         Assert.True(limiter.IdleDuration < previousIdleDuration);
+    }
+
+    [Fact]
+    public async Task GetStatisticsAndGetStatisticsAsyncReturnIdenticalResult()
+    {
+        using var limiter = new RedisSlidingWindowRateLimiter<string>(
+            partitionKey: Guid.NewGuid().ToString(),
+            new RedisSlidingWindowRateLimiterOptions
+            {
+                PermitLimit = 1,
+                Window = TimeSpan.FromMinutes(1),
+                ConnectionMultiplexerFactory = Fixture.ConnectionMultiplexerFactory,
+            });
+
+        using var lease = await limiter.AcquireAsync();
+        Assert.True(lease.IsAcquired);
+
+        using var lease2 = await limiter.AcquireAsync();
+        Assert.False(lease2.IsAcquired);
+
+        var stats = limiter.GetStatistics()!;
+        var asyncStats = await limiter.GetStatisticsAsync()!;
+
+        // The earlier CanAcquireAsyncResource() test validates that the stats are correct,
+        // so here we just want to validate that both methods return the same result.
+        Assert.Equal(stats.TotalSuccessfulLeases, asyncStats.TotalSuccessfulLeases);
+        Assert.Equal(stats.TotalFailedLeases, asyncStats.TotalFailedLeases);
+        Assert.Equal(stats.CurrentAvailablePermits, asyncStats.CurrentAvailablePermits);
+
+        lease.Dispose();
+        lease2.Dispose();
+
+        stats = limiter.GetStatistics()!;
+        asyncStats = await limiter.GetStatisticsAsync();
+        Assert.Equal(stats.CurrentAvailablePermits, asyncStats.CurrentAvailablePermits);
     }
 }

--- a/test/RedisRateLimiting.Tests/UnitTests/TestFixture.cs
+++ b/test/RedisRateLimiting.Tests/UnitTests/TestFixture.cs
@@ -1,13 +1,13 @@
 ﻿using Microsoft.Extensions.Configuration;
+
 using StackExchange.Redis;
 
 namespace RedisRateLimiting.Tests.UnitTests;
 
-public class TestFixture : IDisposable
+public class TestFixture
 {
     public readonly IConfiguration Configuration;
-    public readonly IConnectionMultiplexer ConnectionMultiplexer;
-    public Func<IConnectionMultiplexer> ConnectionMultiplexerFactory;
+    public readonly ConfigurationOptions RedisOptions;
 
     public TestFixture()
     {
@@ -17,23 +17,17 @@ public class TestFixture : IDisposable
             .AddEnvironmentVariables()
             .Build();
 
-        var redisOptions = ConfigurationOptions.Parse(Configuration.GetConnectionString("Redis"));
-        ConnectionMultiplexer = StackExchange.Redis.ConnectionMultiplexer.Connect(redisOptions);
-
-        ConnectionMultiplexerFactory = () => ConnectionMultiplexer;
+        RedisOptions = ConfigurationOptions.Parse(Configuration.GetConnectionString("Redis"));
     }
 
-    public void Dispose()
+    public IConnectionMultiplexer ConnectionMultiplexerFactory()
     {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            ConnectionMultiplexer?.Dispose();
-        }
+        // Because the RateLimiters use a Factory pattern to create the IConnectionMultiplexer,
+        // they should be responsible for disposal.
+        // Ergo the implementation of ConnectionMultiplexerFactory must return a unique instance
+        // of the ConnectionMultiplexer on every call. Inefficient for the Unit Tests, but
+        // inconsequential in real-world scenarios where the RateLimiter itself will only be
+        // instantiated once.
+        return StackExchange.Redis.ConnectionMultiplexer.Connect(RedisOptions);
     }
 }


### PR DESCRIPTION
Extended the Async support, to better support consumers other than the Microsoft.AspNetCore.RateLimiting middleware - just because they can't make use of it does not mean proper Async methods are worthless, especially given #66.

This also allows avoidance of the un-awaited async call that exists in ConcurrencyLease.Dispose() --> RedisConcurrencyRateLimiter.Release() --> RedisConcurrencyManager.ReleaseLeaseAsync()